### PR TITLE
prefixeded unsupported css property column-fill

### DIFF
--- a/src/js/app.vue
+++ b/src/js/app.vue
@@ -56,7 +56,7 @@ ul {
 .category-list {
   overflow: hidden;
   width: 100%;
-  column-fill: auto;
+  -webkit-column-fill: auto;
   column-count: 1;
   column-gap: 0;
 }


### PR DESCRIPTION
Answer to issue #28 

Prefixed the Firefox unsupported CSS property `column-fill` with `-webkit-column-fill`
 